### PR TITLE
add a namespace to svg tags, fixes github previews

### DIFF
--- a/logoglyph.lua
+++ b/logoglyph.lua
@@ -371,7 +371,7 @@ local function writeSceneSvg(source, target)
 	-- boilerplate start
 	local boilerplate = table.concat({
 		'<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
-		'<svg version="1.1" width="1000" height="1000" ',
+		'<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" ',
 		'\t\tviewBox="-500 -500 1000 1000" ',
 		'\t\tpreserveAspectRatio="meet" > ',
 		'\t\t<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" >',

--- a/samples/1.svg
+++ b/samples/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(97.112231128351,-23.858217981938) " >

--- a/samples/10.svg
+++ b/samples/10.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-99.96864237296,2.5041050511691) skewY(2.6378488996233) " >

--- a/samples/100.svg
+++ b/samples/100.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewY(1.8462334367932) " >

--- a/samples/11.svg
+++ b/samples/11.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(14.601101679727,0) skewY(3.0643141347893) rotate(6.1808631201126) skewY(2.5355267125564) translate(5.5208960548043,-1.9731279183179) translate(4.9515071231872,-0.89480237103999) " >

--- a/samples/12.svg
+++ b/samples/12.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(80.596979148686,0) skewY(6.2491273044814) skewY(1.8127487370611) rotate(4.4059321671369) skewY(1.9537433244745) skewY(6.0076739891987) rotate(0.016950275875598) skewY(5.0065663664879) skewY(0.0041494442467226) skewY(2.6738018815522) translate(6.8069393932819,-1.8859359342605) " >

--- a/samples/13.svg
+++ b/samples/13.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-4.8985871965894e-14) skewX(4.9597426860822) rotate(1.1916077821728) skewY(5.51940692543) skewX(1.6867676214648) skewY(6.0910569491537) skewY(3.9366496516822) " >

--- a/samples/14.svg
+++ b/samples/14.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-92.167512568121,-38.79625789951) " >

--- a/samples/15.svg
+++ b/samples/15.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(35.17177477479,0) " >

--- a/samples/16.svg
+++ b/samples/16.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(61.651460127905,0) rotate(2.3994386938641) " >

--- a/samples/17.svg
+++ b/samples/17.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/18.svg
+++ b/samples/18.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(5.5109105961631e-14,100.0) skewX(6.1803131565416) " >

--- a/samples/19.svg
+++ b/samples/19.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/2.svg
+++ b/samples/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) translate(-3.4823199175298,3.7192967999727) scale(5.9906212426722,-9.9707848019898) " >

--- a/samples/20.svg
+++ b/samples/20.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) skewX(5.9235095793675) scale(-1.1418935470283,7.0264937449247) translate(-9.1103697568178,9.9715317320079) " >

--- a/samples/21.svg
+++ b/samples/21.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewX(0.39296757690548) rotate(5.3308543956203) scale(8.4953165147454,2.4312952067703) " >

--- a/samples/22.svg
+++ b/samples/22.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) rotate(5.8791908565148) translate(0.66829854622483,0.3127555269748) skewY(1.2057254039199) " >

--- a/samples/23.svg
+++ b/samples/23.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(30.901699437495,95.105651629515) rotate(4.232400239407) " >

--- a/samples/24.svg
+++ b/samples/24.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewX(6.0153106263811) " >

--- a/samples/25.svg
+++ b/samples/25.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-13) " >

--- a/samples/26.svg
+++ b/samples/26.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) rotate(2.519415531381) translate(1.9076783210039,5.6202727742493) skewY(4.6393787386665) skewY(5.5772294647137) scale(9.4225857872516,0.2391245122999) rotate(1.2312888177215) skewX(2.5716014941187) " >

--- a/samples/27.svg
+++ b/samples/27.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.2043642384652e-13) translate(7.5595915783197,4.3582105822861) " >

--- a/samples/28.svg
+++ b/samples/28.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/29.svg
+++ b/samples/29.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(15.073269791901,0) " >

--- a/samples/3.svg
+++ b/samples/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-93.023150713769,36.697321854372) skewY(2.4327646816139) rotate(5.9711370250018) skewY(0.67544114438911) skewX(2.202500629849) " >

--- a/samples/30.svg
+++ b/samples/30.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(85.656092502177,0) translate(6.5365643333644,-8.7951142527163) translate(-9.6622977219522,-9.7505990602076) translate(9.8713889624923,-2.7253190800548) skewY(0.20328804134004) skewY(5.7943394954636) " >

--- a/samples/31.svg
+++ b/samples/31.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(95.228945245459,-30.519632819503) " >

--- a/samples/32.svg
+++ b/samples/32.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(58.6234618444,0) scale(2.0737381838262,9.342604316771) skewX(1.8731174706326) skewX(1.5629728866772) skewY(5.7515921923983) " >

--- a/samples/33.svg
+++ b/samples/33.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(25.475518917665,0) scale(-7.2879403270781,2.6944716088474) " >

--- a/samples/34.svg
+++ b/samples/34.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(23.61140740104,0) " >

--- a/samples/35.svg
+++ b/samples/35.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(14.374995883554,0) " >

--- a/samples/36.svg
+++ b/samples/36.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/37.svg
+++ b/samples/37.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(91.706622997299,0) " >

--- a/samples/38.svg
+++ b/samples/38.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) translate(-7.652405705303,7.0325300376862) rotate(5.1860748353705) skewY(5.0068067327058) " >

--- a/samples/39.svg
+++ b/samples/39.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(70.542644422963,70.878313452109) translate(8.0583900585771,4.581949301064) translate(-9.770953701809,-0.77111169695854) " >

--- a/samples/4.svg
+++ b/samples/4.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(87.723489146349,48.00613973223) " >

--- a/samples/40.svg
+++ b/samples/40.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) rotate(1.2116864644734) " >

--- a/samples/41.svg
+++ b/samples/41.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-18.301023500673,98.311100791456) " >

--- a/samples/42.svg
+++ b/samples/42.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewX(0.39072101457286) skewY(3.9758965253292) " >

--- a/samples/43.svg
+++ b/samples/43.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(27.635210286826,0) rotate(0.045401051090299) " >

--- a/samples/44.svg
+++ b/samples/44.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewY(1.1118948389517) " >

--- a/samples/45.svg
+++ b/samples/45.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(42.93003170751,0) scale(8.3094790671021,6.3840146921575) " >

--- a/samples/46.svg
+++ b/samples/46.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-80.901699437495,-58.778525229247) skewX(6.2807815104118) " >

--- a/samples/47.svg
+++ b/samples/47.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewY(0.42146588232858) rotate(1.2844191613736) skewX(5.2260836786765) " >

--- a/samples/48.svg
+++ b/samples/48.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(72.470926819369,0) rotate(1.27457358226) " >

--- a/samples/49.svg
+++ b/samples/49.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(24.38271776773,0) rotate(2.6696501580791) " >

--- a/samples/5.svg
+++ b/samples/5.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/50.svg
+++ b/samples/50.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/51.svg
+++ b/samples/51.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) scale(5.7428402639925,-1.0478572361171) " >

--- a/samples/52.svg
+++ b/samples/52.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewX(6.1297412927633) translate(-5.6365394312888,-7.9008660186082) translate(7.1359520964324,-7.0704536419362) " >

--- a/samples/53.svg
+++ b/samples/53.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(18.30149688758,0) rotate(5.5343920341913) " >

--- a/samples/54.svg
+++ b/samples/54.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-63.096406888482,77.581205441545) " >

--- a/samples/55.svg
+++ b/samples/55.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/56.svg
+++ b/samples/56.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(3.0616169978684e-14,100.0) translate(-1.7969106137753,9.6789241954684) skewX(4.9293694580354) " >

--- a/samples/57.svg
+++ b/samples/57.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/58.svg
+++ b/samples/58.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(48.105995543301,0) skewY(5.8923394998429) scale(-0.36290174350142,0.62364821322262) translate(6.2879828549922,-5.9782993979752) skewX(3.3201837821357) scale(0.46690021641552,-8.3257500361651) skewX(2.1388883464964) translate(1.5148207638413,9.5794656407088) skewY(2.7239118962411) skewX(5.7465007400903) scale(7.0475791208446,-0.34161445684731) skewY(0.088603517709302) " >

--- a/samples/59.svg
+++ b/samples/59.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(57.449488155544,0) " >

--- a/samples/6.svg
+++ b/samples/6.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(6.8318908568472,0) skewY(3.859487399759) rotate(1.2358886534832) " >

--- a/samples/60.svg
+++ b/samples/60.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) skewX(0.9840333381955) " >

--- a/samples/61.svg
+++ b/samples/61.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(62.15010014253,78.341336804228) translate(-6.1273756530136,1.25498149544) " >

--- a/samples/62.svg
+++ b/samples/62.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-100.0,3.6739403974421e-14) skewX(5.1369340565741) skewY(6.1209673976954) scale(9.6634988859296,2.3125836718827) skewY(5.552070047443) " >

--- a/samples/63.svg
+++ b/samples/63.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) rotate(2.4169963206612) " >

--- a/samples/64.svg
+++ b/samples/64.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(3.0616169978684e-14,100.0) rotate(0.38668442275261) rotate(3.337664883688) skewY(1.2220808543786) " >

--- a/samples/65.svg
+++ b/samples/65.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/66.svg
+++ b/samples/66.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(10.962318442762,0) skewY(5.3078111537196) " >

--- a/samples/67.svg
+++ b/samples/67.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(63.201319333166,0) rotate(1.2121691191836) translate(-1.6689454764128,-5.2027382701635) translate(7.1904078871012,-6.9208996742964) translate(5.946798780933,-4.1025035642087) " >

--- a/samples/68.svg
+++ b/samples/68.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-63.175227622639,-77.517034352636) " >

--- a/samples/69.svg
+++ b/samples/69.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) rotate(5.26523207453) translate(5.7710463833064,-2.0527719613165) " >

--- a/samples/7.svg
+++ b/samples/7.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) rotate(2.9273019790431) skewX(6.2119084712418) skewY(3.714054356929) scale(6.3365291245282,4.181216545403) rotate(1.6297069903976) scale(-0.75823768973351,3.7172141857445) skewY(5.5452785877743) scale(-0.045353155583143,0.078680049628019) " >

--- a/samples/70.svg
+++ b/samples/70.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-100.0,1.1021821192326e-13) rotate(5.9906632362897) " >

--- a/samples/71.svg
+++ b/samples/71.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/72.svg
+++ b/samples/72.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(65.455027995631,0) " >

--- a/samples/73.svg
+++ b/samples/73.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(78.498474135995,0) " >

--- a/samples/74.svg
+++ b/samples/74.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) scale(-9.398806411773,-8.1575298029929) " >

--- a/samples/75.svg
+++ b/samples/75.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(62.348980185873,78.183148246803) skewY(1.0915608715946) skewX(2.5455675619752) rotate(3.926035879656) rotate(4.5048649631935) rotate(1.1977385558527) rotate(5.1516642986735) skewX(5.9165784373548) " >

--- a/samples/76.svg
+++ b/samples/76.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(4.3167252559215,0) rotate(1.3627887215518) translate(2.4406844377518,6.0991908609867) skewY(0.68667473432465) rotate(0.76953667600569) scale(-0.018530283123255,-7.903994647786) " >

--- a/samples/77.svg
+++ b/samples/77.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) skewX(0.22303333338786) scale(-4.3524180725217,-5.3717309702188) skewY(2.2235502742855) " >

--- a/samples/78.svg
+++ b/samples/78.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-98.555906229255,-16.933202512529) " >

--- a/samples/79.svg
+++ b/samples/79.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/8.svg
+++ b/samples/8.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(23.887130245566,0) rotate(0.57351641460928) skewY(3.3602145282513) scale(5.9027597680688,8.4762502927333) " >

--- a/samples/80.svg
+++ b/samples/80.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(70.710678118655,70.710678118655) " >

--- a/samples/81.svg
+++ b/samples/81.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(53.386847255751,0) translate(-7.7896342147142,2.5907819718122) scale(-8.6506345216185,7.446975260973) rotate(5.3411333027723) " >

--- a/samples/82.svg
+++ b/samples/82.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(50.854753796011,0) " >

--- a/samples/83.svg
+++ b/samples/83.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(5.6796783115715,0) " >

--- a/samples/84.svg
+++ b/samples/84.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) rotate(0.22900715936454) translate(-0.99685647524893,0.68628675304353) rotate(4.1379763792342) translate(4.3924162909389,9.7204810008407) " >

--- a/samples/85.svg
+++ b/samples/85.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(11.67222391814,0) " >

--- a/samples/86.svg
+++ b/samples/86.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0.88413027115166,0) skewY(1.8863025493983) " >

--- a/samples/87.svg
+++ b/samples/87.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(30.901699437495,95.105651629515) skewY(5.5666572190801) skewY(2.8149452740667) rotate(2.8704968173601) " >

--- a/samples/88.svg
+++ b/samples/88.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(22.842735191807,0) skewY(4.1299301630256) " >

--- a/samples/89.svg
+++ b/samples/89.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(35.081787575415,93.644370789244) translate(4.1739559173584,-3.8973515946418) scale(5.9649995900691,5.3849406260997) scale(-1.4690833631903,-6.0825158003718) " >

--- a/samples/9.svg
+++ b/samples/9.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(8.6590023515108,99.624403025948) " >

--- a/samples/90.svg
+++ b/samples/90.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(76.605478674173,0) translate(2.0326712541282,-6.2059906776994) " >

--- a/samples/91.svg
+++ b/samples/91.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(56.84082088992,0) " >

--- a/samples/92.svg
+++ b/samples/92.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(100.0,-2.4492935982947e-14) " >

--- a/samples/93.svg
+++ b/samples/93.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) " >

--- a/samples/94.svg
+++ b/samples/94.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(50.163208413869,0) rotate(5.4556286857246) " >

--- a/samples/95.svg
+++ b/samples/95.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(57.256178371608,0) " >

--- a/samples/96.svg
+++ b/samples/96.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) scale(-0.26085103861988,3.7693667318672) translate(0.49134206958115,3.9624657854438) " >

--- a/samples/97.svg
+++ b/samples/97.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(-52.705302514202,-84.983240035235) " >

--- a/samples/98.svg
+++ b/samples/98.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(45.234028110281,0) skewY(4.2737572816824) " >

--- a/samples/99.svg
+++ b/samples/99.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" width="1000" height="1000" 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1000" height="1000" 
 		viewBox="-500 -500 1000 1000" 
 		preserveAspectRatio="meet" > 
 		<g style="fill:none;stroke:black;stroke-width:10;stroke-opacity:1" ><g transform="translate(0,0) rotate(2.4120515258907) " >


### PR DESCRIPTION
This fixes GitHub image previews (_"Sorry, this file is invalid so it cannot be displayed."_), rendering SVGs in `<img>` tags, and maybe some other viewers.

Changes:
- added `xmlns` attribute to `<svg>` tag in `logoglyph.lua`
- modifed existing files in `samples/` using simple search & replace: `sed -i 's/<svg/<svg xmlns="http:\/\/www.w3.org\/2000\/svg"/' samples/*svg` (so the actual generated images are the same ones as in master branch)